### PR TITLE
Fix for linuxmint

### DIFF
--- a/game.c
+++ b/game.c
@@ -38,13 +38,6 @@ static void randomize(struct game_state *state)
 
 static struct game_state *game_init()
 {
-    initscr();
-    raw();
-    timeout(0);
-    noecho();
-    curs_set(0);
-    keypad(stdscr, TRUE);
-
     int width, height;
     getmaxyx(stdscr, height, width);
     struct game_state *state = malloc(sizeof(*state) + width * height * 2);
@@ -70,7 +63,6 @@ static void game_unload(struct game_state *state)
 static void game_finalize(struct game_state *state)
 {
     free(state);
-    endwin();
 }
 
 static int count(struct game_state *state, int x, int y)

--- a/main.c
+++ b/main.c
@@ -4,6 +4,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dlfcn.h>
+#include <ncurses.h>
 #include "game.h"
 
 const char *GAME_LIBRARY = "./libgame.so";
@@ -56,9 +57,25 @@ void game_unload(struct game *game)
     }
 }
 
+void ncurses_start(void)
+{
+    initscr();
+    raw();
+    timeout(0);
+    noecho();
+    curs_set(0);
+    keypad(stdscr, TRUE);
+}
+
+void ncurses_end(void)
+{
+    endwin();
+}
+
 int main(void)
 {
     struct game game = {0};
+    ncurses_start();
     for (;;) {
         game_load(&game);
         if (game.handle)
@@ -67,5 +84,6 @@ int main(void)
         usleep(100000);
     }
     game_unload(&game);
+    ncurses_end();
     return 0;
 }


### PR DESCRIPTION
Before this patch, ncurses would freeze after libgame.so was
reloaded in main.c. After posting the issue on Stackoverflow,
it's because the game shared lib owns ncurses due to the
--as-needed switch to the linker being default in this
(distro|version of GCC).

The fix recommended by the Stackoverflow answer causes the
display to drop back to the terminal for an instant, so I
changed it a little.

main.c now starts up and brings down ncurses, so it now owns
the all important handle to the screen, stdscr. Now when
the game library is recompiled, this screen handle no longer
goes out of scope, and the game continues as expected!
- http://stackoverflow.com/questions/27881111
