### PR TITLE
Add final game unload call to trigger ncurses endwin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gdb*
 *.so
 main
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
-CFLAGS  = -std=c99 -pedantic -Wall -O2 -fPIC
-LDLIBS  = -ldl -lncurses
+WARNING_FLAGS = -Wall
+CFLAGS  = -std=c99 -pedantic $(WARNING_FLAGS) -O2 -fPIC
 
-all : main libgame.so libfun_pointer.so alternate_libfun_pointer.so
+LDLIBS  = -ldl
 
-main : main.c game.h
+all : tags main libgame.so libfun_pointer.so alternate_libfun_pointer.so
+
+main : main.c game.h reload_patch.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)
 
 libgame.so : game.c game.h
-	$(CC) $(CFLAGS) -shared $(LDFLAGS) -o $@ $< $(LDLIBS)
+	$(CC) $(CFLAGS) -shared $(LDFLAGS) -o $@ $< $(LDLIBS) -lncurses
 	make reload
 
 libfun_pointer.so : fun_pointer.c game.h

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,29 @@
 CFLAGS  = -std=c99 -pedantic -Wall -O2 -fPIC
 LDLIBS  = -ldl -lncurses
 
-RUNNING_INSTANCE_PID := $(shell pidof main)
-
-all : main libgame.so
+all : main libgame.so libfun_pointer.so alternate_libfun_pointer.so
 
 main : main.c game.h
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)
 
 libgame.so : game.c game.h
 	$(CC) $(CFLAGS) -shared $(LDFLAGS) -o $@ $< $(LDLIBS)
-ifneq "$(RUNNING_INSTANCE_PID)" ""
-	@killall -USR1 main
-endif
+	make reload
+
+libfun_pointer.so : fun_pointer.c game.h
+	$(CC) $(CFLAGS) -shared $(LDFLAGS) -o $@ $< $(LDLIBS)
+	make reload
+
+alternate_libfun_pointer.so : alternate_fun_pointer.c game.h
+	$(CC) $(CFLAGS) -shared $(LDFLAGS) -o alternate_libfun_pointer.so $< $(LDLIBS)
+
+reload:
+	pkill --signal USR1 main || true
 
 test : main libgame.so
 	./$<
 
 clean :
 	$(RM) *.o *.so main
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 CFLAGS  = -std=c99 -pedantic -Wall -O2 -fPIC
 LDLIBS  = -ldl -lncurses
 
+RUNNING_INSTANCE_PID := $(shell pidof main)
+
 all : main libgame.so
 
 main : main.c game.h
@@ -8,6 +10,9 @@ main : main.c game.h
 
 libgame.so : game.c game.h
 	$(CC) $(CFLAGS) -shared $(LDFLAGS) -o $@ $< $(LDLIBS)
+ifneq "$(RUNNING_INSTANCE_PID)" ""
+	@killall -USR1 main
+endif
 
 test : main libgame.so
 	./$<

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS  = -std=c99 -pedantic $(WARNING_FLAGS) -O2 -fPIC
 
 LDLIBS  = -ldl
 
-all : tags main libgame.so libfun_pointer.so alternate_libfun_pointer.so
+all : main libgame.so libfun_pointer.so alternate_libfun_pointer.so
 
 main : main.c game.h reload_patch.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)

--- a/alternate_fun_pointer.c
+++ b/alternate_fun_pointer.c
@@ -1,0 +1,50 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include "game.h"
+
+struct game_state {
+    void (*f)();
+    bool should_call_f;
+};
+
+static void g(){
+    printf("g defined on %s:%d 0x%lx\n", __FILE__, __LINE__, (unsigned long int)g);
+}
+
+static void f(){
+    printf("f defined on %s:%d 0x%lx\n", __FILE__, __LINE__, (unsigned long int)f);
+}
+
+static struct game_state *game_init() {
+    struct game_state *state = malloc(sizeof(*state));
+    state->f = f;
+    return state;
+}
+
+static void game_reload(struct game_state *state){
+    state->should_call_f = true;
+}
+
+static void game_unload(struct game_state *state){
+}
+
+static void game_finalize(struct game_state *state){
+    free(state);
+}
+
+static bool game_step(struct game_state *state){
+    if(state->should_call_f){
+        state->f();
+        state->should_call_f = false;
+    }
+    return true;
+}
+
+const struct game_api GAME_API = {
+    .init = game_init,
+    .reload = game_reload,
+    .step = game_step,
+    .unload = game_unload,
+    .finalize = game_finalize
+};

--- a/alternate_fun_pointer.c
+++ b/alternate_fun_pointer.c
@@ -8,12 +8,11 @@ struct game_state {
     bool should_call_f;
 };
 
-static void g(){
-    printf("g defined on %s:%d 0x%lx\n", __FILE__, __LINE__, (unsigned long int)g);
-}
+char bytes[4096];
 
+__attribute__((noinline))
 static void f(){
-    printf("f defined on %s:%d 0x%lx\n", __FILE__, __LINE__, (unsigned long int)f);
+    printf("\tf defined on %s:%d 0x%lx\n", __FILE__, __LINE__, (unsigned long int)f);
 }
 
 static struct game_state *game_init() {

--- a/alternate_fun_pointer.c
+++ b/alternate_fun_pointer.c
@@ -8,12 +8,13 @@ struct game_state {
     bool should_call_f;
 };
 
-char bytes[4096];
-
 __attribute__((noinline))
 static void f(){
     printf("\tf defined on %s:%d 0x%lx\n", __FILE__, __LINE__, (unsigned long int)f);
 }
+
+char bytes[4096];
+
 
 static struct game_state *game_init() {
     struct game_state *state = malloc(sizeof(*state));

--- a/fun_pointer.c
+++ b/fun_pointer.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include "game.h"
+
+struct game_state {
+    void (*f)();
+    bool should_call_f;
+};
+
+static void f(){
+    printf("f defined on %s:%d 0x%lx\n", __FILE__, __LINE__, (unsigned long int)f);
+}
+
+static struct game_state *game_init() {
+    struct game_state *state = malloc(sizeof(*state));
+    state->f = f;
+    return state;
+}
+
+static void game_reload(struct game_state *state){
+    state->should_call_f = true;
+}
+
+static void game_unload(struct game_state *state){
+}
+
+static void game_finalize(struct game_state *state){
+    free(state);
+}
+
+static bool game_step(struct game_state *state){
+    if(state->should_call_f){
+        state->f();
+        state->should_call_f = false;
+    }
+    return true;
+}
+
+const struct game_api GAME_API = {
+    .init = game_init,
+    .reload = game_reload,
+    .step = game_step,
+    .unload = game_unload,
+    .finalize = game_finalize
+};

--- a/fun_pointer.c
+++ b/fun_pointer.c
@@ -9,7 +9,7 @@ struct game_state {
 };
 
 static void f(){
-    printf("f defined on %s:%d 0x%lx\n", __FILE__, __LINE__, (unsigned long int)f);
+    printf("\tf defined on %s:%d 0x%lx\n", __FILE__, __LINE__, (unsigned long int)f);
 }
 
 static struct game_state *game_init() {

--- a/fun_pointer.c
+++ b/fun_pointer.c
@@ -8,6 +8,8 @@ struct game_state {
     bool should_call_f;
 };
 
+char bytes[2048];
+
 static void f(){
     printf("\tf defined on %s:%d 0x%lx\n", __FILE__, __LINE__, (unsigned long int)f);
 }

--- a/main.c
+++ b/main.c
@@ -48,6 +48,7 @@ static void game_load(struct game *game)
 void game_unload(struct game *game)
 {
     if (game->handle) {
+        game->api.unload(game->state);
         game->api.finalize(game->state);
         game->state = NULL;
         dlclose(game->handle);

--- a/main.c
+++ b/main.c
@@ -6,6 +6,8 @@
 #include <stdbool.h>
 #include "game.h"
 
+#include "reload_patch.c"       // Comment out to disable shared object symbol patching
+
 char *global_game_library_file_name = 0;
 
 struct game{
@@ -29,6 +31,9 @@ static void game_reload(struct game *game){
 
     void *handle = dlopen(global_game_library_file_name, RTLD_NOW);
     if(handle){
+#if ENABLE_RELOAD_PATCH
+        patch_so_symbols(handle);
+#endif
         game->handle = handle;
         const struct game_api *api = dlsym(game->handle, "GAME_API");
         if(api != NULL){

--- a/reload_patch.c
+++ b/reload_patch.c
@@ -1,33 +1,22 @@
 #define ENABLE_RELOAD_PATCH 1
 #define LNX_DLL_PATCH_VERBOSE 1
 
+#include <elf.h>
+#include <link.h>
+int dlinfo(void *handle, int request, void *info); // These two lines to avoid defining _GNU_SOURCE
+#define RTLD_DI_LINKMAP 2
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
-
-// TODO: Put something more general here
-// #define ASSERT(expr) {if(!(expr)){fprintf(stderr, "Assertion failed: %s, line %d (%s)\n", __FILE__, __LINE__, #expr); __builtin_debugtrap();}}
-#define ASSERT(expr) {if(!(expr)){fprintf(stderr, "Assertion failed: %s, line %d (%s)\n", __FILE__, __LINE__, #expr); assert(false);}}
-
-#define MIN(a, b) (((a)<(b))?(a):(b))
-#define MAX(a, b) (((a)>(b))?(a):(b))
 
 typedef uint8_t Byte;
 typedef uint32_t U32;
 typedef uint64_t U64;
-#define U64MAX 0xffffffffffffffffUL
-
-#include <elf.h>
-#include <link.h>
-// These two lines to avoid defining _GNU_SOURCE
-int dlinfo(void *handle, int request, void *info);
-#define RTLD_DI_LINKMAP 2
 
 static Byte * read_entire_file(char *file_name){
     Byte *result = 0;
-
     FILE *f = fopen(file_name, "rb");
     if(f){
         fseek(f, 0, SEEK_END);
@@ -49,61 +38,61 @@ static Byte * read_entire_file(char *file_name){
 
 struct SymbolReplacement{
     char *name;
-    void *neg_addr_prev;            // Negated addresses of symbols to avoid patching them by mistake
-    void *neg_addr_cur;
+    void *neg_addr_prev;            // We store SymbolReplacements in the heap, but we don't want to patch them
+    void *neg_addr_cur;             // so we negate them to prevent patch_so_symbols from detecting them
     struct SymbolReplacement *next;
-    bool take_into_account;
 };
 
-#define FILE_MAGIC_NUMBER(a, b, c, d) (((U32)(a) << 0) | ((U32)(b) << 8) | ((U32)(c) << 16) | ((U32)(d) << 24))
-#define ELF_MAGIC_VALUE FILE_MAGIC_NUMBER(127, 'E', 'L', 'F')
 #define NEGATE_PTR(addr) (void *)~((U64)(addr))
-#define NEGATE_U64(addr) (~((U64)(addr)))
-
 static void patch_so_symbols(void *so_handle){
     static struct SymbolReplacement symbol_replacement_sentinel = {0};
     for(struct SymbolReplacement *sr = symbol_replacement_sentinel.next; sr; sr = sr->next){
-        sr->neg_addr_prev = sr->neg_addr_cur;           // Cycle cur to prev
+        sr->neg_addr_prev = sr->neg_addr_cur;
         sr->neg_addr_cur = 0;
-        sr->take_into_account = 0;
     }
 
-    /* Parse .so and put addresses of symbols on sr->neg_addr_cur */ {
+    /* Parse .so and put addresses of visible symbols on sr->neg_addr_cur */ {
+#define ASSERT_OR_GOTO(message, condition, label) if(!(condition)){ error_message = message; goto label; }
+        char *error_message = 0;
         struct link_map * link_map = 0;
-        int ret = dlinfo(so_handle, RTLD_DI_LINKMAP, &link_map);                ASSERT(ret != -1);
+        Byte *contents = 0;
 
+        ASSERT_OR_GOTO("patch_so_symbols assumes 64-bit pointers", sizeof(void *) == 8, so_parse_end);
+
+        int ret = dlinfo(so_handle, RTLD_DI_LINKMAP, &link_map);
+        ASSERT_OR_GOTO("Unable to dlinfo shared object", ret == 0, so_parse_end);
         char *so_path = link_map->l_name;
-        Byte *contents = read_entire_file(so_path);                             ASSERT(contents);
-        // Info for non-exported, local symbols is only available on the .symtab section, 
-        // which is not loaded into memory through dlopen (which looks at the .dynsym section). 
-        // That's why we resort to parsing the .so file
-        Elf64_Ehdr *elf_header = (Elf64_Ehdr *) contents;
+        contents = read_entire_file(so_path);
+        ASSERT_OR_GOTO("Unable to read shared object", contents != 0, so_parse_end);
 
-        // Make sure this is the binary type we think it is
-        ASSERT(*(U32*)elf_header->e_ident == ELF_MAGIC_VALUE);
-        ASSERT(elf_header->e_ident[EI_CLASS] == ELFCLASS64);
-        ASSERT(elf_header->e_ident[EI_DATA] == ELFDATA2LSB);
-        ASSERT(elf_header->e_machine == EM_X86_64);
-        ASSERT(elf_header->e_ident[EI_VERSION] == EV_CURRENT);
-        ASSERT(elf_header->e_type == ET_DYN);
+        // Info for non-exported, local symbols is only available on the .symtab section of the shared object.
+        // dlopen only looks at the .dynsym section. That's why we resort to parsing the .so file
+        Elf64_Ehdr *elf_header = (Elf64_Ehdr *) contents;          
+
+        Byte elf_magic_number[4] = {0x7F, 'E', 'L', 'F'};
+        ASSERT_OR_GOTO("Unexpected binary type",
+                       !memcmp(elf_header->e_ident, elf_magic_number, 4) && elf_header->e_ident[EI_CLASS] == ELFCLASS64 &&
+                       elf_header->e_ident[EI_DATA] == ELFDATA2LSB   && elf_header->e_machine == EM_X86_64 &&
+                       elf_header->e_ident[EI_VERSION] == EV_CURRENT && elf_header->e_type == ET_DYN, so_parse_end);
+
+        ASSERT_OR_GOTO("Undefined section header string table", elf_header->e_shstrndx != SHN_UNDEF, so_parse_end);
 
         Elf64_Shdr *symtab_header, *strtab_header; {
-            symtab_header = 0;  // Contains info about both local and global symbols
+            symtab_header = 0;  // Lists local and global symbols
             strtab_header = 0;  // String section for stuff other than section names
 
             Elf64_Shdr *first_elf_section_header = (Elf64_Shdr *)((Byte *)elf_header + elf_header->e_shoff);
-            ASSERT(elf_header->e_shstrndx != SHN_UNDEF); // Section index containing the string table
             Elf64_Shdr *section_header_string_table = first_elf_section_header + elf_header->e_shstrndx;
-            ASSERT(section_header_string_table->sh_type == SHT_STRTAB);
+
+            ASSERT_OR_GOTO("Unexpected section header string table type", 
+                           section_header_string_table->sh_type == SHT_STRTAB, so_parse_end);
+
             char *section_string_table = (char *)elf_header + section_header_string_table->sh_offset;
 
             U32 section_count = elf_header->e_shnum;
             for(U32 i_section = 0; i_section < section_count; ++i_section){
                 Elf64_Shdr *elf_section_header = first_elf_section_header + i_section;
                 char *section_name = section_string_table + elf_section_header->sh_name;
-#if 0
-                printf("Section %d, type %d name: \"%.*s\"\n", i_section, elf_section_header->sh_type, SE(section_name));
-#endif
                 if(!strcmp(section_name, ".symtab")){
                     symtab_header = elf_section_header;
                 }
@@ -111,26 +100,30 @@ static void patch_so_symbols(void *so_handle){
                     strtab_header = elf_section_header;
                 }
             }
-            ASSERT(symtab_header && strtab_header);
+            ASSERT_OR_GOTO("Unable to locate .symtab section", symtab_header, so_parse_end);
+            ASSERT_OR_GOTO("Unable to locate .strtab section", strtab_header, so_parse_end);
         }
 
         char *string_table = (char *)elf_header + strtab_header->sh_offset;
 
         char *symtab = (char *)elf_header + symtab_header->sh_offset;
-        ASSERT(symtab_header->sh_size % symtab_header->sh_entsize == 0);
+        ASSERT_OR_GOTO(".symtab size not a multiple of entry size",
+                       symtab_header->sh_size % symtab_header->sh_entsize == 0, so_parse_end);
+        ASSERT_OR_GOTO(".symtab entry size not equal to sizeof(Elf64_Sym)", 
+                       symtab_header->sh_entsize == sizeof(Elf64_Sym), so_parse_end);
+
         U32 entry_count = symtab_header->sh_size / symtab_header->sh_entsize;
         Elf64_Sym *entries = (Elf64_Sym *)symtab;
-        ASSERT(symtab_header->sh_entsize == sizeof(*entries));
 
-        // TODO: Comment
+        // Add visible symbols to linked list
         for(U32 i_entry = 0; i_entry < entry_count; ++i_entry){
             Elf64_Sym *entry = entries + i_entry;
-#if 0
-            if(ELF64_ST_TYPE(entry->st_info) == STT_FUNC || ELF64_ST_TYPE(entry->st_info) == STT_OBJECT)
-#endif
-            if(entry->st_value && entry->st_name){
-                char *symbol_name = string_table + entry->st_name;
-
+            char *symbol_name = string_table + entry->st_name;
+            bool is_func_or_var = (ELF64_ST_TYPE(entry->st_info) == STT_FUNC ||
+                                   ELF64_ST_TYPE(entry->st_info) == STT_OBJECT);
+            bool is_named_and_non_reserved = (symbol_name[0] != 0 && symbol_name[0] != '_');
+            if(is_func_or_var && is_named_and_non_reserved){
+                // Sort asciibetically
                 struct SymbolReplacement *insert_after = &symbol_replacement_sentinel;
                 for(struct SymbolReplacement *sr = symbol_replacement_sentinel.next; sr; sr = sr->next){
                     int cmp = strcmp(sr->name, symbol_name);
@@ -138,9 +131,6 @@ static void patch_so_symbols(void *so_handle){
                         void *addr = (Byte *)link_map->l_addr + entry->st_value;
                         sr->neg_addr_cur = NEGATE_PTR(addr);
                         insert_after = 0;
-                        if(sr->neg_addr_prev != sr->neg_addr_cur){
-                            sr->take_into_account = true;
-                        }
                         break;
                     }
                     else if(cmp < 0){
@@ -163,27 +153,27 @@ static void patch_so_symbols(void *so_handle){
             }
         }
 
-        free(contents);
+        so_parse_end:
+        if(error_message){
+            fprintf(stderr, "Error parsing shared object: %s\n", error_message);
+        }
+        if(contents){
+            free(contents);
+        }
+#undef ASSERT_OR_GOTO
     }
 
     void *min_addr, *max_addr; {
-        min_addr = (void *)U64MAX; 
+        min_addr = (void *) UINTPTR_MAX;
         max_addr = 0;
-
         for(struct SymbolReplacement *sr = symbol_replacement_sentinel.next; sr; sr = sr->next){
-            if(sr->take_into_account){
-                void *addr = NEGATE_PTR(sr->neg_addr_prev);
-                min_addr = MIN(min_addr, addr);
-                max_addr = MAX(max_addr, addr);
-            }
+            void *addr = NEGATE_PTR(sr->neg_addr_prev);
+            min_addr = addr < min_addr ? addr : min_addr;
+            max_addr = addr > max_addr ? addr : max_addr;
         }
-        min_addr = (Byte *) min_addr - 1;      // This is to avoid patching of min_addr and max_addr
-        max_addr = (Byte *) max_addr + 1;      // TODO: Check if it's necessary
     }
 
-    FILE *f = fopen("/proc/self/maps", "rb"); // 'man proc', section on /proc/[pid]/maps
 
-    char line[4096];
     U64 memory_beg, memory_end;
     char rwxp[4];
     U64 offset;
@@ -191,23 +181,24 @@ static void patch_so_symbols(void *so_handle){
     U64 inode;
     char path[4096];
 
+    char line[4096];
+    FILE *f = fopen("/proc/self/maps", "rb"); // Format described on 'man proc', section on /proc/[pid]/maps
     while(!feof(f)){
         fgets(line, sizeof(line), f);
-
         int ret = sscanf(line, "%lx-%lx %4c %lx %x:%x %lu %s", 
                          &memory_beg, &memory_end, rwxp, &offset, &dev_major, &dev_minor, &inode, path);
-        
+
+        // Look for r/w [heap] sections
         if(ret == 8 && rwxp[0] == 'r' && rwxp[1] == 'w' && rwxp[2] == '-' && !strcmp(path, "[heap]")){
             // Interpret contents of memory segment as a pointer and see if it falls inside the library range
             void **first = (void **)memory_beg;
             void **last = (void **) ((Byte *)memory_end - sizeof(void *));
 
-            // Could speed this up
             for(void **addrp = first; addrp <= last; addrp = (void **)((Byte *)addrp+1)) {
                 if(*addrp >= min_addr && *addrp <= max_addr){
                     for(struct SymbolReplacement *sr = symbol_replacement_sentinel.next; sr; sr = sr->next){
-                        if(sr->take_into_account && NEGATE_U64(sr->neg_addr_prev) == (U64)*addrp){
-                            ASSERT(sr->neg_addr_cur && sr->neg_addr_prev != sr->neg_addr_cur);
+                        if(sr->neg_addr_prev && sr->neg_addr_cur && sr->neg_addr_prev != sr->neg_addr_cur &&
+                           *addrp == NEGATE_PTR(sr->neg_addr_prev)){
 #if LNX_DLL_PATCH_VERBOSE
                             printf("(%p, %s) ", (void*)addrp, sr->name);
 #endif
@@ -220,3 +211,4 @@ static void patch_so_symbols(void *so_handle){
     }
     fclose(f);
 }
+#undef NEGATE_PTR

--- a/reload_patch.c
+++ b/reload_patch.c
@@ -1,0 +1,222 @@
+#define ENABLE_RELOAD_PATCH 1
+#define LNX_DLL_PATCH_VERBOSE 1
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+// TODO: Put something more general here
+// #define ASSERT(expr) {if(!(expr)){fprintf(stderr, "Assertion failed: %s, line %d (%s)\n", __FILE__, __LINE__, #expr); __builtin_debugtrap();}}
+#define ASSERT(expr) {if(!(expr)){fprintf(stderr, "Assertion failed: %s, line %d (%s)\n", __FILE__, __LINE__, #expr); assert(false);}}
+
+#define MIN(a, b) (((a)<(b))?(a):(b))
+#define MAX(a, b) (((a)>(b))?(a):(b))
+
+typedef uint8_t Byte;
+typedef uint32_t U32;
+typedef uint64_t U64;
+#define U64MAX 0xffffffffffffffffUL
+
+#include <elf.h>
+#include <link.h>
+// These two lines to avoid defining _GNU_SOURCE
+int dlinfo(void *handle, int request, void *info);
+#define RTLD_DI_LINKMAP 2
+
+static Byte * read_entire_file(char *file_name){
+    Byte *result = 0;
+
+    FILE *f = fopen(file_name, "rb");
+    if(f){
+        fseek(f, 0, SEEK_END);
+        ssize_t size = ftell(f);
+        fseek(f, 0, SEEK_SET);
+
+        result = calloc(1, size);
+        if(result){
+            ssize_t bytes_read = fread(result, 1, size, f);
+            if(bytes_read != size){
+                free(result);
+                result = 0;
+            }
+        }
+        fclose(f);
+    }
+    return result;
+}
+
+struct SymbolReplacement{
+    char *name;
+    void *neg_addr_prev;            // Negated addresses of symbols to avoid patching them by mistake
+    void *neg_addr_cur;
+    struct SymbolReplacement *next;
+    bool take_into_account;
+};
+
+#define FILE_MAGIC_NUMBER(a, b, c, d) (((U32)(a) << 0) | ((U32)(b) << 8) | ((U32)(c) << 16) | ((U32)(d) << 24))
+#define ELF_MAGIC_VALUE FILE_MAGIC_NUMBER(127, 'E', 'L', 'F')
+#define NEGATE_PTR(addr) (void *)~((U64)(addr))
+#define NEGATE_U64(addr) (~((U64)(addr)))
+
+static void patch_so_symbols(void *so_handle){
+    static struct SymbolReplacement symbol_replacement_sentinel = {0};
+    for(struct SymbolReplacement *sr = symbol_replacement_sentinel.next; sr; sr = sr->next){
+        sr->neg_addr_prev = sr->neg_addr_cur;           // Cycle cur to prev
+        sr->neg_addr_cur = 0;
+        sr->take_into_account = 0;
+    }
+
+    /* Parse .so and put addresses of symbols on sr->neg_addr_cur */ {
+        struct link_map * link_map = 0;
+        int ret = dlinfo(so_handle, RTLD_DI_LINKMAP, &link_map);                ASSERT(ret != -1);
+
+        char *so_path = link_map->l_name;
+        Byte *contents = read_entire_file(so_path);                             ASSERT(contents);
+        // Info for non-exported, local symbols is only available on the .symtab section, 
+        // which is not loaded into memory through dlopen (which looks at the .dynsym section). 
+        // That's why we resort to parsing the .so file
+        Elf64_Ehdr *elf_header = (Elf64_Ehdr *) contents;
+
+        // Make sure this is the binary type we think it is
+        ASSERT(*(U32*)elf_header->e_ident == ELF_MAGIC_VALUE);
+        ASSERT(elf_header->e_ident[EI_CLASS] == ELFCLASS64);
+        ASSERT(elf_header->e_ident[EI_DATA] == ELFDATA2LSB);
+        ASSERT(elf_header->e_machine == EM_X86_64);
+        ASSERT(elf_header->e_ident[EI_VERSION] == EV_CURRENT);
+        ASSERT(elf_header->e_type == ET_DYN);
+
+        Elf64_Shdr *symtab_header, *strtab_header; {
+            symtab_header = 0;  // Contains info about both local and global symbols
+            strtab_header = 0;  // String section for stuff other than section names
+
+            Elf64_Shdr *first_elf_section_header = (Elf64_Shdr *)((Byte *)elf_header + elf_header->e_shoff);
+            ASSERT(elf_header->e_shstrndx != SHN_UNDEF); // Section index containing the string table
+            Elf64_Shdr *section_header_string_table = first_elf_section_header + elf_header->e_shstrndx;
+            ASSERT(section_header_string_table->sh_type == SHT_STRTAB);
+            char *section_string_table = (char *)elf_header + section_header_string_table->sh_offset;
+
+            U32 section_count = elf_header->e_shnum;
+            for(U32 i_section = 0; i_section < section_count; ++i_section){
+                Elf64_Shdr *elf_section_header = first_elf_section_header + i_section;
+                char *section_name = section_string_table + elf_section_header->sh_name;
+#if 0
+                printf("Section %d, type %d name: \"%.*s\"\n", i_section, elf_section_header->sh_type, SE(section_name));
+#endif
+                if(!strcmp(section_name, ".symtab")){
+                    symtab_header = elf_section_header;
+                }
+                else if(!strcmp(section_name, ".strtab")){
+                    strtab_header = elf_section_header;
+                }
+            }
+            ASSERT(symtab_header && strtab_header);
+        }
+
+        char *string_table = (char *)elf_header + strtab_header->sh_offset;
+
+        char *symtab = (char *)elf_header + symtab_header->sh_offset;
+        ASSERT(symtab_header->sh_size % symtab_header->sh_entsize == 0);
+        U32 entry_count = symtab_header->sh_size / symtab_header->sh_entsize;
+        Elf64_Sym *entries = (Elf64_Sym *)symtab;
+        ASSERT(symtab_header->sh_entsize == sizeof(*entries));
+
+        // TODO: Comment
+        for(U32 i_entry = 0; i_entry < entry_count; ++i_entry){
+            Elf64_Sym *entry = entries + i_entry;
+#if 0
+            if(ELF64_ST_TYPE(entry->st_info) == STT_FUNC || ELF64_ST_TYPE(entry->st_info) == STT_OBJECT)
+#endif
+            if(entry->st_value && entry->st_name){
+                char *symbol_name = string_table + entry->st_name;
+
+                struct SymbolReplacement *insert_after = &symbol_replacement_sentinel;
+                for(struct SymbolReplacement *sr = symbol_replacement_sentinel.next; sr; sr = sr->next){
+                    int cmp = strcmp(sr->name, symbol_name);
+                    if(!cmp){
+                        void *addr = (Byte *)link_map->l_addr + entry->st_value;
+                        sr->neg_addr_cur = NEGATE_PTR(addr);
+                        insert_after = 0;
+                        if(sr->neg_addr_prev != sr->neg_addr_cur){
+                            sr->take_into_account = true;
+                        }
+                        break;
+                    }
+                    else if(cmp < 0){
+                        insert_after = sr;
+                    }
+                    else{
+                        break;
+                    }
+                }
+
+                if(insert_after){
+                    struct SymbolReplacement *sr = calloc(1, sizeof(struct SymbolReplacement)); {
+                        sr->name = strdup(symbol_name);
+                        void *addr = (Byte *)link_map->l_addr + entry->st_value;
+                        sr->neg_addr_cur = NEGATE_PTR(addr);
+                        sr->next = insert_after->next;
+                    }
+                    insert_after->next = sr;
+                }
+            }
+        }
+
+        free(contents);
+    }
+
+    void *min_addr, *max_addr; {
+        min_addr = (void *)U64MAX; 
+        max_addr = 0;
+
+        for(struct SymbolReplacement *sr = symbol_replacement_sentinel.next; sr; sr = sr->next){
+            if(sr->take_into_account){
+                void *addr = NEGATE_PTR(sr->neg_addr_prev);
+                min_addr = MIN(min_addr, addr);
+                max_addr = MAX(max_addr, addr);
+            }
+        }
+        min_addr = (Byte *) min_addr - 1;      // This is to avoid patching of min_addr and max_addr
+        max_addr = (Byte *) max_addr + 1;      // TODO: Check if it's necessary
+    }
+
+    FILE *f = fopen("/proc/self/maps", "rb"); // 'man proc', section on /proc/[pid]/maps
+
+    char line[4096];
+    U64 memory_beg, memory_end;
+    char rwxp[4];
+    U64 offset;
+    U32 dev_major, dev_minor;
+    U64 inode;
+    char path[4096];
+
+    while(!feof(f)){
+        fgets(line, sizeof(line), f);
+
+        int ret = sscanf(line, "%lx-%lx %4c %lx %x:%x %lu %s", 
+                         &memory_beg, &memory_end, rwxp, &offset, &dev_major, &dev_minor, &inode, path);
+        
+        if(ret == 8 && rwxp[0] == 'r' && rwxp[1] == 'w' && rwxp[2] == '-' && !strcmp(path, "[heap]")){
+            // Interpret contents of memory segment as a pointer and see if it falls inside the library range
+            void **first = (void **)memory_beg;
+            void **last = (void **) ((Byte *)memory_end - sizeof(void *));
+
+            // Could speed this up
+            for(void **addrp = first; addrp <= last; addrp = (void **)((Byte *)addrp+1)) {
+                if(*addrp >= min_addr && *addrp <= max_addr){
+                    for(struct SymbolReplacement *sr = symbol_replacement_sentinel.next; sr; sr = sr->next){
+                        if(sr->take_into_account && NEGATE_U64(sr->neg_addr_prev) == (U64)*addrp){
+                            ASSERT(sr->neg_addr_cur && sr->neg_addr_prev != sr->neg_addr_cur);
+#if LNX_DLL_PATCH_VERBOSE
+                            printf("(%p, %s) ", (void*)addrp, sr->name);
+#endif
+                            *addrp = NEGATE_PTR(sr->neg_addr_cur);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    fclose(f);
+}

--- a/test_fun_pointer.sh
+++ b/test_fun_pointer.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "* Cleaning"
+make -s clean 
+echo "* Compiling"
+make -s
+
+echo "* Running libfun"
+./main ./libfun_pointer.so &
+sleep 1
+echo "* Hot-loading alternate libfun"
+mv alternate_libfun_pointer.so libfun_pointer.so
+pkill --signal USR1 main
+sleep 1
+pkill main
+
+

--- a/test_fun_pointer.sh
+++ b/test_fun_pointer.sh
@@ -9,7 +9,8 @@ echo "* Running libfun"
 ./main ./libfun_pointer.so &
 sleep 1
 echo "* Hot-loading alternate libfun"
-mv alternate_libfun_pointer.so libfun_pointer.so
+rm libfun_pointer.so
+cp alternate_libfun_pointer.so libfun_pointer.so
 pkill --signal USR1 main
 sleep 1
 pkill main


### PR DESCRIPTION
The previous commit moves the endwin call from `game.c:game_finalize` to `game.c:game_unload`, but `main.c:game_unload` doesn't call `game.c:game_unload`, leaving ncurses active when the application exits.
